### PR TITLE
feat(client): Radar convar and toggle event

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,23 @@ Go to releases and get the latest version.
 
 This is a development resource, if you don't use the exports the resource itself will do nothing.
 
-## ConVars
+## Events
+
+- `fivem-appearance:toggleUI` (_boolean_)  
+This client event is triggered each time the interface is opened or closed.  
+The first and only parameter indicates current state of the interface:  
+  - `true` - opened
+  - `false` - closed
+
+## Convars
 
 Since this is a client script, you will need to use **setr** to set these convars.
 
-- **fivem-appearance:locale**: the name of one file inside `locales/`, default **en**, choose the locale file for the customization interface.
+| Convar                  | Default | Type   | Description
+| ---                     | ---     | ---    | ---
+| fivem-appearance:locale | "en"    | string | Name of a file inside `locales/`. Choose the locale file for the customization interface.
+| fivem-appearance:radar  | 1       | int    | Enables hiding/showing the radar when opening the customization interface.
+
 
 config.cfg example:
 
@@ -75,13 +87,6 @@ ensure fivem-appearance
 | setPedEyeColor      | ped: _number_, eyeColor: _number_              | _void_            |
 | setPlayerAppearance | appearance: _PedAppearance_                    | _void_            |
 | setPedAppearance    | ped: _number_, appearance: _PedAppearance_     | _void_            |
-
-### Customization
-
-This export is only available if **fivem-appearance:customization** is set to 1.
-
-| Export                   | Parameters                                                                                    | Return |
-| ------------------------ | --------------------------------------------------------------------------------------------- | ------ |
 | startPlayerCustomization | callback: _((appearance: PedAppearance \| undefined) => void)_, config? _CustomizationConfig_ | _void_ |
 
 ## Examples
@@ -99,8 +104,8 @@ RegisterCommand('customization', function()
     props = true,
   }
 
-  exports['fivem-appearance']:startPlayerCustomization(function (appearance)
-    if (appearance) then
+  exports['fivem-appearance']:startPlayerCustomization(function(appearance)
+    if appearance then
       print('Saved')
     else
       print('Canceled')

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This is a development resource, if you don't use the exports the resource itself
 
 ## Events
 
-- `fivem-appearance:toggleUI` (_boolean_)  
+- `fivem-appearance:uiStateChanged` (_boolean_)  
 This client event is triggered each time the interface is opened or closed.  
 The first and only parameter indicates current state of the interface:  
   - `true` - opened

--- a/README.md
+++ b/README.md
@@ -37,14 +37,6 @@ Go to releases and get the latest version.
 
 This is a development resource, if you don't use the exports the resource itself will do nothing.
 
-## Events
-
-- `fivem-appearance:uiStateChanged` (_boolean_)  
-This client event is triggered each time the interface is opened or closed.  
-The first and only parameter indicates current state of the interface:  
-  - `true` - opened
-  - `false` - closed
-
 ## Convars
 
 Since this is a client script, you will need to use **setr** to set these convars.

--- a/client/customisation.lua
+++ b/client/customisation.lua
@@ -298,7 +298,7 @@ function client.startPlayerCustomization(cb, _config)
 	TaskStandStill(playerPed, -1)
 
 	if toggleRadar then DisplayRadar(false) end
-	TriggerEvent('fivem-appearance:toggleUI', true)
+	TriggerEvent('fivem-appearance:uiStateChanged', true)
 
 	local nuiMessage = {
 		type = 'appearance_display',
@@ -314,7 +314,7 @@ function client.exitPlayerCustomization(appearance)
 	SetNuiFocus(false, false)
 
 	if toggleRadar then DisplayRadar(true) end
-	TriggerEvent('fivem-appearance:toggleUI', false)
+	TriggerEvent('fivem-appearance:uiStateChanged', false)
 
 	local playerPed = PlayerPedId()
 

--- a/client/customisation.lua
+++ b/client/customisation.lua
@@ -277,6 +277,7 @@ client.pedTurnAround = pedTurnAround
 local playerHeading
 function client.getHeading() return playerHeading end
 
+local toggleRadar = GetConvarInt('fivem-appearance:radar', 1) == 1
 local callback
 function client.startPlayerCustomization(cb, _config)
 	local playerPed = PlayerPedId()
@@ -293,9 +294,11 @@ function client.startPlayerCustomization(cb, _config)
 	SetNuiFocus(true, true)
 	SetNuiFocusKeepInput(false)
 	RenderScriptCams(true, false, 0, true, true)
-	DisplayRadar(false)
 	SetEntityInvincible(playerPed, true)
 	TaskStandStill(playerPed, -1)
+
+	if toggleRadar then DisplayRadar(false) end
+	TriggerEvent('fivem-appearance:toggleUI', true)
 
 	local nuiMessage = {
 		type = 'appearance_display',
@@ -308,8 +311,10 @@ end
 function client.exitPlayerCustomization(appearance)
 	RenderScriptCams(false, false, 0, true, true)
 	DestroyCam(cameraHandle, false)
-	DisplayRadar(true)
 	SetNuiFocus(false, false)
+
+	if toggleRadar then DisplayRadar(true) end
+	TriggerEvent('fivem-appearance:toggleUI', false)
 
 	local playerPed = PlayerPedId()
 

--- a/client/customisation.lua
+++ b/client/customisation.lua
@@ -298,7 +298,6 @@ function client.startPlayerCustomization(cb, _config)
 	TaskStandStill(playerPed, -1)
 
 	if toggleRadar then DisplayRadar(false) end
-	TriggerEvent('fivem-appearance:uiStateChanged', true)
 
 	local nuiMessage = {
 		type = 'appearance_display',
@@ -314,7 +313,6 @@ function client.exitPlayerCustomization(appearance)
 	SetNuiFocus(false, false)
 
 	if toggleRadar then DisplayRadar(true) end
-	TriggerEvent('fivem-appearance:uiStateChanged', false)
 
 	local playerPed = PlayerPedId()
 


### PR DESCRIPTION
- Added a convar to enable hiding/showing the radar when opening the customization interface.
- Added an event that is triggered each time the interface is opened or closed.
This can be usefull for people who wants to disable some UI elements while using the menu.