### PR TITLE
Fix broken ped head overlays number

### DIFF
--- a/client/customisation.lua
+++ b/client/customisation.lua
@@ -133,7 +133,7 @@ local function getAppearanceSettings()
 		local settings = {
 			style = {
 				min = 0,
-				max = GetPedHeadOverlayNum(i) - 1
+				max = GetPedHeadOverlayNum(i - 1) - 1
 			},
 			opacity = {
 				min = 0,


### PR DESCRIPTION
It wasn't getting the number for the right overlayID, now it is.